### PR TITLE
63 spacial data serialization format design and implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ crossterm = "0.27.0"
 hound = "3.5.1"
 libc = "0.2.150"
 rand = "0.8.5"
-ratatui = "0.24.0"
+ratatui = "0.26.0"
 rayon = "1.8.0"
+ron = "0.8.1"
 serde = { version = "1.0.190", features = ["derive"] }
-slint = "1.3.0"
-tokio = "1.34.0"
+tempfile = "3.10.0"
 
 [build-dependencies]
 bindgen = "0.69.1"

--- a/src/bin/monitor/gui.rs
+++ b/src/bin/monitor/gui.rs
@@ -22,9 +22,9 @@ use std::{
 use cg::Point;
 
 // This is a function pointer in Rust! The important bit is on the right side. The
-// FnMut says that it is a function, () means that it takes no arguments, and 
+// FnMut says that it is a function, () means that it takes no arguments, and
 // -> Vec<Point> means that it returns a vector of Points. The whole thing put
-// together, FunMut() -> Vec<Point>, is **not** a type!! It is a trait. Every 
+// together, FunMut() -> Vec<Point>, is **not** a type!! It is a trait. Every
 // individual function in Rust is its own type, but it implements a trait that
 // describes its arguments and return values. FunMut() -> Vec<Point> is one of
 // those such traits.
@@ -34,7 +34,7 @@ use cg::Point;
 // needs to be a full type. This is basically saying that we will take a Box that
 // contains anything that implements the FunMut() -> Vec<Point> trait. It needs to
 // be in a Box because the function itself could be of a variable size, so it must
-// be allocated on the heap, hence the Box. 
+// be allocated on the heap, hence the Box.
 type PointGenerator = Box<dyn FnMut() -> Vec<Point>>;
 
 /// This struct contains function pointers that generate original/debug points

--- a/src/bin/monitor/main.rs
+++ b/src/bin/monitor/main.rs
@@ -14,7 +14,6 @@ use cg::update_accumulator::UpdateAccumulator;
 use gui::engage_gui;
 
 fn main() {
-
     // Configure, instantiate, and start the dummy HDM.
     let hdm = DummyHdm::builder()
         .num_points(10)
@@ -29,7 +28,7 @@ fn main() {
     //
     // This is called the **interior mutability pattern**.
     let hdm_rf = Rc::new(RefCell::new(hdm));
-    
+
     // Now we're going to shadow over the hdm variable with a reference so that
     // we don't accidentially do something funky with the original thing.
     let hdm = hdm_rf.clone();
@@ -43,12 +42,12 @@ fn main() {
     // Ok now this is the wonky bit. We're going to define closures to pass into
     // this function. The || indicates that this is a closure that takes no arguments
     // and move indicates that captured variables will be _moved_ into the scope
-    // of the function, rather than being borrowed. 
-    // 
-    // So, we move the debug_hdm_handle into the first closure, then .borrow() 
-    // to turn the Rc<RefCell<T>> into an &T, which we can then call the 
+    // of the function, rather than being borrowed.
+    //
+    // So, we move the debug_hdm_handle into the first closure, then .borrow()
+    // to turn the Rc<RefCell<T>> into an &T, which we can then call the
     // .get_debug_locations() on.
-    // 
+    //
     // Remember that those closures are **not** being run immediately, they are
     // instead run roughly every quarter second by the GUI.
     let _ = engage_gui(

--- a/src/hardware_data_manager.rs
+++ b/src/hardware_data_manager.rs
@@ -17,7 +17,7 @@ pub type Id = usize;
 // to work.
 
 /// This struct represents a radial measurement taken from `src` to `dst`. `azm`
-/// represents the radians of the angle from `src` to `dst` in the x/y plane, 
+/// represents the radians of the angle from `src` to `dst` in the x/y plane,
 /// which we call the "azimuth". `elv` represents the angle from `src` to `dst`
 /// _above_ the x/y plane, this is called "elevation".
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod hardware_data_manager;
 pub mod localizer;
 pub mod saf;
 mod saf_raw;
+pub mod spatial_data_format;
 pub mod update_accumulator;
 
 use std::fmt::Display;

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -123,7 +123,7 @@ impl GrapeFile {
 
         let s_buf: Vec<u8> = self.samples.iter().flat_map(|f| f.to_be_bytes()).collect();
 
-        file.write_all(&s_buf).map_err(GrapeFileError::IoError)?;
+        file.write_all(&s_buf).map_err(GrapeFileError::IoError)
 
         Ok(())
     }

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -190,17 +190,16 @@ impl GrapeFile {
     /// Returns a cloned, de-interleaved version of the samples in the file.
     fn get_raw_streams(&self) -> Vec<Vec<f32>> {
         let n_streams = self.header.n_streams as usize;
-        if n_streams == 0 {
-            return Vec::new();
-        }
-        let stream_len = self.samples.len() / n_streams;
-        let mut sample_vecs = vec![Vec::with_capacity(stream_len); n_streams];
-
-        for (i, &e) in self.samples.iter().enumerate() {
-            let stream_idx = i % n_streams;
-            sample_vecs[stream_idx].push(e);
-        }
-        sample_vecs
+        (0..n_streams)
+            .map(|i| {
+                self.samples
+                    .iter()
+                    .skip(i)
+                    .step_by(n_streams)
+                    .cloned()
+                    .collect()
+            })
+            .collect()
     }
 
     /// Extracts the streams from the file, and interpolates data points to

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -1,0 +1,251 @@
+//! TODO
+//!
+//!
+
+#![allow(unused)]
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+};
+
+const A_FLOAT: f32 = 12.07843112945556640625;
+
+#[derive(Debug, Clone, PartialEq)]
+struct GrapeFile {
+    header: GrapeFileHeader,
+    samples: Vec<f32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+struct GrapeFileHeader {
+    n_streams: u64,
+    sample_rate: u64,
+    tags: Vec<GrapeTag>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
+enum GrapeTag {
+    X,
+    Y,
+    Z,
+    Azimuth,
+    Elevation,
+    Range,
+    Pitch,
+    Yaw,
+    Roll,
+}
+
+#[derive(Debug)]
+enum GrapeFileError {
+    UnequalSampleBufferLengths,
+    NoDelimiter,
+    TryInto,
+    IoError(std::io::Error),
+    RonError(ron::Error),
+    RonSpannedError(ron::de::SpannedError),
+}
+
+impl GrapeFile {
+    pub fn builder() -> GrapeFileBuilder {
+        GrapeFileBuilder::new()
+    }
+
+    pub fn to_file(&self, path: impl AsRef<Path>) -> Result<(), GrapeFileError> {
+        let mut handle = File::create(path).map_err(|e| GrapeFileError::IoError(e))?;
+
+        let h_str = ron::ser::to_string(&self.header).map_err(|e| GrapeFileError::RonError(e))?;
+        let h_buf = h_str.as_bytes();
+
+        handle
+            .write_all(h_buf)
+            .map_err(|e| GrapeFileError::IoError(e))?;
+
+        handle
+            .write_all(&[0xFF])
+            .map_err(|e| GrapeFileError::IoError(e))?;
+
+        let s_buf: Vec<u8> = self.samples.iter().flat_map(|f| f.to_be_bytes()).collect();
+
+        handle
+            .write_all(&s_buf)
+            .map_err(|e| GrapeFileError::IoError(e))?;
+
+        Ok(())
+    }
+
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, GrapeFileError> {
+        let mut handle = File::open(path).map_err(|e| GrapeFileError::IoError(e))?;
+
+        let mut raw_text = Vec::new();
+        handle
+            .read_to_end(&mut raw_text)
+            .map_err(|e| GrapeFileError::IoError(e))?;
+
+        let delim_idx = raw_text
+            .iter()
+            .position(|e| *e == 0xFF)
+            .ok_or(GrapeFileError::NoDelimiter)?;
+
+        let (header_buf, samples_buf) = raw_text.split_at(delim_idx);
+        let (_, samples_buf) = samples_buf
+            .split_first()
+            .ok_or(GrapeFileError::NoDelimiter)?;
+
+        let header = ron::de::from_bytes::<GrapeFileHeader>(header_buf)
+            .map_err(|e| GrapeFileError::RonSpannedError(e))?;
+
+        let samples: Vec<f32> = samples_buf
+            .chunks(4)
+            .map(|bs| -> Result<f32, GrapeFileError> {
+                let four_bytes: [u8; 4] =
+                    bs[0..4].try_into().map_err(|_| GrapeFileError::TryInto)?;
+                Ok(f32::from_be_bytes(four_bytes))
+            })
+            .collect::<Result<Vec<f32>, GrapeFileError>>()?;
+
+        Ok(GrapeFile { header, samples })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GrapeFileBuilder {
+    n_streams: u64,
+    sample_rate: u64,
+    streams: Vec<(GrapeTag, Vec<f32>)>,
+}
+
+impl GrapeFileBuilder {
+    fn new() -> Self {
+        GrapeFileBuilder {
+            n_streams: 0,
+            sample_rate: 0,
+            streams: Vec::new(),
+        }
+    }
+
+    pub fn set_samplerate(self, sample_rate: u64) -> Self {
+        GrapeFileBuilder {
+            sample_rate,
+            ..self
+        }
+    }
+
+    pub fn add_stream(mut self, stream: &[f32], tag: GrapeTag) -> Self {
+        let stream: Vec<f32> = stream.to_vec();
+        self.streams.push((tag, stream));
+        self.n_streams += 1;
+        self
+    }
+
+    pub fn clear_streams(mut self) -> Self {
+        self.streams.clear();
+        self.n_streams = 0;
+        self
+    }
+
+    pub fn build_truncate(self) -> GrapeFile {
+        let tags: Vec<GrapeTag> = self
+            .streams
+            .iter()
+            .map(|(tag, _vec)| tag)
+            .cloned()
+            .collect();
+        let sample_vecs: Vec<Vec<f32>> = self.streams.into_iter().map(|(_tag, vec)| vec).collect();
+
+        let mut samples = Vec::new();
+
+        if sample_vecs.len() != 0 {
+            let shortest = sample_vecs.iter().map(|v| v.len()).min().unwrap();
+            samples.reserve_exact(shortest * self.n_streams as usize);
+            for sample_idx in 0..shortest {
+                for stream_idx in 0..self.n_streams {
+                    samples.push(sample_vecs[stream_idx as usize][sample_idx]);
+                }
+            }
+        };
+
+        GrapeFile {
+            header: GrapeFileHeader {
+                n_streams: self.n_streams,
+                sample_rate: self.sample_rate,
+                tags,
+            },
+            samples,
+        }
+    }
+
+    pub fn build_extend(self) -> GrapeFile {
+        let tags: Vec<GrapeTag> = self
+            .streams
+            .iter()
+            .map(|(tag, _vec)| tag)
+            .cloned()
+            .collect();
+        let sample_vecs: Vec<Vec<f32>> = self.streams.into_iter().map(|(_tag, vec)| vec).collect();
+
+        let mut samples = Vec::new();
+
+        if sample_vecs.len() != 0 {
+            let longest = sample_vecs.iter().map(|v| v.len()).max().unwrap();
+            let lasts: Vec<f32> = sample_vecs
+                .iter()
+                .map(|v| v.last().unwrap_or(&0.0))
+                .cloned()
+                .collect();
+            samples.reserve_exact(longest * self.n_streams as usize);
+            for sample_idx in 0..longest {
+                for stream_idx in 0..self.n_streams as usize {
+                    samples.push(
+                        sample_vecs[stream_idx as usize]
+                            .get(sample_idx)
+                            .unwrap_or(&lasts[stream_idx])
+                            .clone(),
+                    );
+                }
+            }
+        };
+
+        GrapeFile {
+            header: GrapeFileHeader {
+                n_streams: self.n_streams,
+                sample_rate: self.sample_rate,
+                tags,
+            },
+            samples,
+        }
+    }
+
+    pub fn build(self) -> Result<GrapeFile, GrapeFileError> {
+        let lens: Vec<usize> = self.streams.iter().map(|(_tag, v)| v.len()).collect();
+
+        if lens.windows(2).all(|w| w[0] == w[1]) {
+            Ok(self.build_truncate())
+        } else {
+            Err(GrapeFileError::UnequalSampleBufferLengths)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_and_read() {
+        let mut tempfile = tempfile::NamedTempFile::new().unwrap();
+        let path = tempfile.path();
+        let data = GrapeFile::builder()
+            .set_samplerate(1000)
+            .add_stream(&vec![A_FLOAT; 4], GrapeTag::X)
+            .add_stream(&vec![A_FLOAT; 4], GrapeTag::Y)
+            .build()
+            .unwrap();
+
+        data.to_file(path).unwrap();
+        let read_data = GrapeFile::from_file(path).unwrap();
+        assert_eq!(data, read_data);
+    }
+}

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -24,14 +24,14 @@ use std::{
 
 /// This struct contains the header and samples associated with a GrapeFile
 #[derive(Debug, Clone, PartialEq)]
-struct GrapeFile {
+pub struct GrapeFile {
     header: GrapeFileHeader,
     samples: Vec<f32>,
 }
 
 /// This struct contains the header data for a [GrapeFile].
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-struct GrapeFileHeader {
+pub struct GrapeFileHeader {
     n_streams: u64,
     sample_rate: u64,
     tags: Vec<GrapeTag>,
@@ -44,7 +44,7 @@ struct GrapeFileHeader {
 /// [GrapeTag::Pitch], [GrapeTag::Yaw], and [GrapeTag::Roll] represent angular
 /// directions.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
-enum GrapeTag {
+pub enum GrapeTag {
     X,
     Y,
     Z,
@@ -58,7 +58,7 @@ enum GrapeTag {
 
 ///
 #[derive(Debug)]
-enum GrapeFileError {
+pub enum GrapeFileError {
     UnequalSampleBufferLengths,
     NoDelimiter,
     TryInto,
@@ -228,7 +228,7 @@ impl GrapeFile {
 
 /// This builder contains the data required
 #[derive(Debug, Clone)]
-struct GrapeFileBuilder {
+pub struct GrapeFileBuilder {
     sample_rate: u64,
     streams: Vec<(GrapeTag, Vec<f32>)>,
 }

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -2,15 +2,12 @@
 //!
 //!
 
-#![allow(unused)]
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
     io::{Read, Write},
     path::Path,
 };
-
-const A_FLOAT: f32 = 12.07843112945556640625;
 
 #[derive(Debug, Clone, PartialEq)]
 struct GrapeFile {
@@ -54,35 +51,29 @@ impl GrapeFile {
     }
 
     pub fn to_file(&self, path: impl AsRef<Path>) -> Result<(), GrapeFileError> {
-        let mut handle = File::create(path).map_err(|e| GrapeFileError::IoError(e))?;
+        let mut handle = File::create(path).map_err(GrapeFileError::IoError)?;
 
-        let h_str = ron::ser::to_string(&self.header).map_err(|e| GrapeFileError::RonError(e))?;
+        let h_str = ron::ser::to_string(&self.header).map_err(GrapeFileError::RonError)?;
         let h_buf = h_str.as_bytes();
 
-        handle
-            .write_all(h_buf)
-            .map_err(|e| GrapeFileError::IoError(e))?;
+        handle.write_all(h_buf).map_err(GrapeFileError::IoError)?;
 
-        handle
-            .write_all(&[0xFF])
-            .map_err(|e| GrapeFileError::IoError(e))?;
+        handle.write_all(&[0xFF]).map_err(GrapeFileError::IoError)?;
 
         let s_buf: Vec<u8> = self.samples.iter().flat_map(|f| f.to_be_bytes()).collect();
 
-        handle
-            .write_all(&s_buf)
-            .map_err(|e| GrapeFileError::IoError(e))?;
+        handle.write_all(&s_buf).map_err(GrapeFileError::IoError)?;
 
         Ok(())
     }
 
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self, GrapeFileError> {
-        let mut handle = File::open(path).map_err(|e| GrapeFileError::IoError(e))?;
+        let mut handle = File::open(path).map_err(GrapeFileError::IoError)?;
 
         let mut raw_text = Vec::new();
         handle
             .read_to_end(&mut raw_text)
-            .map_err(|e| GrapeFileError::IoError(e))?;
+            .map_err(GrapeFileError::IoError)?;
 
         let delim_idx = raw_text
             .iter()
@@ -95,7 +86,7 @@ impl GrapeFile {
             .ok_or(GrapeFileError::NoDelimiter)?;
 
         let header = ron::de::from_bytes::<GrapeFileHeader>(header_buf)
-            .map_err(|e| GrapeFileError::RonSpannedError(e))?;
+            .map_err(GrapeFileError::RonSpannedError)?;
 
         let samples: Vec<f32> = samples_buf
             .chunks(4)
@@ -107,6 +98,75 @@ impl GrapeFile {
             .collect::<Result<Vec<f32>, GrapeFileError>>()?;
 
         Ok(GrapeFile { header, samples })
+    }
+
+    pub fn streams_native_sample_rate(&self) -> (u64, Vec<(GrapeTag, Vec<f32>)>) {
+        let sample_vecs = self.get_raw_streams();
+
+        let res_vecs = Self::attach_tags(&self.header.tags, sample_vecs);
+
+        (self.header.sample_rate, res_vecs)
+    }
+
+    pub fn streams_with_sample_rate(&self, sample_rate: u64) -> Vec<(GrapeTag, Vec<f32>)> {
+        if sample_rate == self.header.sample_rate {
+            self.streams_native_sample_rate().1
+        } else if sample_rate > self.header.sample_rate {
+            self.streams_interpolated(sample_rate)
+        } else {
+            self.streams_quantized(sample_rate)
+        }
+    }
+
+    fn attach_tags(tags: &[GrapeTag], samples: Vec<Vec<f32>>) -> Vec<(GrapeTag, Vec<f32>)> {
+        assert_eq!(tags.len(), samples.len());
+        tags.iter().cloned().zip(samples.into_iter()).collect()
+    }
+
+    fn get_raw_streams(&self) -> Vec<Vec<f32>> {
+        let n_streams = self.header.n_streams as usize;
+        let stream_len = self.samples.len() / n_streams;
+        let mut sample_vecs = vec![Vec::with_capacity(stream_len); n_streams];
+
+        for (i, &e) in self.samples.iter().enumerate() {
+            let stream_idx = i % n_streams;
+            sample_vecs[stream_idx].push(e);
+        }
+        sample_vecs
+    }
+
+    fn streams_interpolated(&self, sample_rate: u64) -> Vec<(GrapeTag, Vec<f32>)> {
+        debug_assert!(sample_rate > self.header.sample_rate);
+        let samples_per_pt = sample_rate as usize / self.header.sample_rate as usize;
+        let raw_streams = self.get_raw_streams();
+        let interpolated_streams = raw_streams
+            .into_iter()
+            .map(|v| {
+                v.windows(2)
+                    .flat_map(|w| {
+                        let step = (w[1] - w[0]) / samples_per_pt as f32;
+                        (0..samples_per_pt)
+                            .map(|i| w[0] + i as f32 * step)
+                            .collect::<Vec<_>>()
+                    }).collect()
+            })
+            .collect();
+        Self::attach_tags(&self.header.tags, interpolated_streams)
+    }
+
+    fn streams_quantized(&self, sample_rate: u64) -> Vec<(GrapeTag, Vec<f32>)> {
+        debug_assert!(sample_rate < self.header.sample_rate);
+        let pts_per_sample = self.header.sample_rate as usize / sample_rate as usize;
+        let raw_streams = self.get_raw_streams();
+        let quantized_streams = raw_streams
+            .into_iter()
+            .map(|v| {
+                v.chunks(pts_per_sample)
+                    .map(|c| c.iter().sum::<f32>() / c.len() as f32)
+                    .collect()
+            })
+            .collect();
+        Self::attach_tags(&self.header.tags, quantized_streams)
     }
 }
 
@@ -157,7 +217,7 @@ impl GrapeFileBuilder {
 
         let mut samples = Vec::new();
 
-        if sample_vecs.len() != 0 {
+        if !sample_vecs.is_empty() {
             let shortest = sample_vecs.iter().map(|v| v.len()).min().unwrap();
             samples.reserve_exact(shortest * self.n_streams as usize);
             for sample_idx in 0..shortest {
@@ -188,7 +248,7 @@ impl GrapeFileBuilder {
 
         let mut samples = Vec::new();
 
-        if sample_vecs.len() != 0 {
+        if !sample_vecs.is_empty() {
             let longest = sample_vecs.iter().map(|v| v.len()).max().unwrap();
             let lasts: Vec<f32> = sample_vecs
                 .iter()
@@ -199,10 +259,9 @@ impl GrapeFileBuilder {
             for sample_idx in 0..longest {
                 for stream_idx in 0..self.n_streams as usize {
                     samples.push(
-                        sample_vecs[stream_idx as usize]
+                        *sample_vecs[stream_idx]
                             .get(sample_idx)
-                            .unwrap_or(&lasts[stream_idx])
-                            .clone(),
+                            .unwrap_or(&lasts[stream_idx]),
                     );
                 }
             }
@@ -230,12 +289,13 @@ impl GrapeFileBuilder {
 }
 
 #[cfg(test)]
+const A_FLOAT: f32 = 12.07843112945556640625;
 mod tests {
     use super::*;
 
     #[test]
     fn write_and_read() {
-        let mut tempfile = tempfile::NamedTempFile::new().unwrap();
+        let tempfile = tempfile::NamedTempFile::new().unwrap();
         let path = tempfile.path();
         let data = GrapeFile::builder()
             .set_samplerate(1000)
@@ -247,5 +307,89 @@ mod tests {
         data.to_file(path).unwrap();
         let read_data = GrapeFile::from_file(path).unwrap();
         assert_eq!(data, read_data);
+    }
+
+    #[test]
+    fn native_sample_rate_read() {
+        let stream_data = vec![
+            (GrapeTag::X, vec![A_FLOAT; 4]),
+            (GrapeTag::Y, vec![A_FLOAT; 4]),
+        ];
+
+        let data = GrapeFile::builder()
+            .set_samplerate(1000)
+            .add_stream(&stream_data[0].1, stream_data[0].0)
+            .add_stream(&stream_data[1].1, stream_data[1].0)
+            .build()
+            .unwrap();
+
+        let (sr, streams) = data.streams_native_sample_rate();
+        assert_eq!(1000, sr);
+        assert_eq!(stream_data, streams);
+    }
+
+    #[test]
+    fn quantize_read() {
+        let stream_data = vec![
+            (GrapeTag::X, vec![A_FLOAT; 4]),
+            (GrapeTag::Y, vec![A_FLOAT; 4]),
+        ];
+
+        let data = GrapeFile::builder()
+            .set_samplerate(1000)
+            .add_stream(&stream_data[0].1, stream_data[0].0)
+            .add_stream(&stream_data[1].1, stream_data[1].0)
+            .build()
+            .unwrap();
+
+        let streams = data.streams_with_sample_rate(500);
+        assert_eq!(
+            vec![
+                (GrapeTag::X, vec![A_FLOAT; 2]),
+                (GrapeTag::Y, vec![A_FLOAT; 2]),
+            ],
+            streams
+        );
+    }
+
+    #[test]
+    fn interpolate_same() {
+        let stream_data = vec![
+            (GrapeTag::X, vec![A_FLOAT; 4]),
+            (GrapeTag::Y, vec![A_FLOAT; 4]),
+        ];
+
+        let data = GrapeFile::builder()
+            .set_samplerate(1000)
+            .add_stream(&stream_data[0].1, stream_data[0].0)
+            .add_stream(&stream_data[1].1, stream_data[1].0)
+            .build()
+            .unwrap();
+
+        let streams = data.streams_with_sample_rate(2000);
+        assert_eq!(
+            vec![
+                (GrapeTag::X, vec![A_FLOAT; 6]),
+                (GrapeTag::Y, vec![A_FLOAT; 6]),
+            ],
+            streams
+        );
+    }
+
+    #[test]
+    fn interpolate_range() {
+        let stream_data = vec![0.0, 0.2, 0.8];
+
+        let data = GrapeFile::builder()
+            .set_samplerate(5)
+            .add_stream(&stream_data, GrapeTag::Yaw)
+            .build()
+            .unwrap();
+
+        let streams = data.streams_with_sample_rate(10);
+        assert_eq!(
+            vec![(GrapeTag::Yaw, vec![0.0, 0.1, 0.2, 0.5])],
+            streams
+        );
     }
 }

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -306,8 +306,8 @@ impl GrapeFileBuilder {
 
         let mut samples = Vec::new();
 
-        if !sample_vecs.is_empty() {
-            let shortest = sample_vecs.iter().map(|v| v.len()).min().unwrap();
+        let shortest = sample_vecs.iter().map(|v| v.len()).min();
+        if let Some(shortest) = shortest {
             samples.reserve_exact(shortest * sample_vecs.len() as usize);
             for sample_idx in 0..shortest {
                 for stream_idx in 0..sample_vecs.len() {

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -339,8 +339,8 @@ impl GrapeFileBuilder {
 
         let mut samples = Vec::new();
 
-        if !sample_vecs.is_empty() {
-            let longest = sample_vecs.iter().map(|v| v.len()).max().unwrap();
+        let longest = sample_vecs.iter().map(|v| v.len()).max();
+        if let Some(longest) = longest {
             let lasts: Vec<f32> = sample_vecs
                 .iter()
                 .map(|v| v.last().unwrap_or(&0.0))

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -148,7 +148,7 @@ impl GrapeFile {
         let (header_buf, samples_buf) = raw_text.split_at(delim_idx);
         let (_, samples_buf) = samples_buf
             .split_first()
-            .ok_or(GrapeFileError::NoDelimiter)?;
+        let samples_buf = &samples_buf[1..];
 
         let header = ron::de::from_bytes::<GrapeFileHeader>(header_buf)
             .map_err(GrapeFileError::RonSpannedError)?;

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -22,7 +22,7 @@ struct GrapeFile {
 /// TODO
 ///
 ///
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 struct GrapeFileHeader {
     n_streams: u64,
     sample_rate: u64,
@@ -32,7 +32,7 @@ struct GrapeFileHeader {
 /// TODO
 ///
 ///
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 enum GrapeTag {
     X,
     Y,
@@ -139,8 +139,8 @@ impl GrapeFile {
     pub fn streams_with_sample_rate(&self, sample_rate: u64) -> Vec<(GrapeTag, Vec<f32>)> {
         match sample_rate.cmp(&self.header.sample_rate) {
             Ordering::Equal => self.streams_native_sample_rate().1,
-            Ordering::Greater => self.streams_quantized(sample_rate),
-            Ordering::Less => self.streams_interpolated(sample_rate),
+            Ordering::Less => self.streams_quantized(sample_rate),
+            Ordering::Greater => self.streams_interpolated(sample_rate),
         }
     }
 

--- a/src/spatial_data_format.rs
+++ b/src/spatial_data_format.rs
@@ -9,12 +9,18 @@ use std::{
     path::Path,
 };
 
+/// TODO
+/// 
+/// 
 #[derive(Debug, Clone, PartialEq)]
 struct GrapeFile {
     header: GrapeFileHeader,
     samples: Vec<f32>,
 }
 
+/// TODO
+/// 
+/// 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 struct GrapeFileHeader {
     n_streams: u64,
@@ -22,6 +28,9 @@ struct GrapeFileHeader {
     tags: Vec<GrapeTag>,
 }
 
+/// TODO
+/// 
+/// 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq)]
 enum GrapeTag {
     X,
@@ -35,6 +44,9 @@ enum GrapeTag {
     Roll,
 }
 
+/// TODO
+/// 
+/// 
 #[derive(Debug)]
 enum GrapeFileError {
     UnequalSampleBufferLengths,
@@ -46,10 +58,17 @@ enum GrapeFileError {
 }
 
 impl GrapeFile {
+
+    /// TODO
+    /// 
+    /// 
     pub fn builder() -> GrapeFileBuilder {
         GrapeFileBuilder::new()
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn to_file(&self, path: impl AsRef<Path>) -> Result<(), GrapeFileError> {
         let mut handle = File::create(path).map_err(GrapeFileError::IoError)?;
 
@@ -67,6 +86,9 @@ impl GrapeFile {
         Ok(())
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self, GrapeFileError> {
         let mut handle = File::open(path).map_err(GrapeFileError::IoError)?;
 
@@ -100,6 +122,9 @@ impl GrapeFile {
         Ok(GrapeFile { header, samples })
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn streams_native_sample_rate(&self) -> (u64, Vec<(GrapeTag, Vec<f32>)>) {
         let sample_vecs = self.get_raw_streams();
 
@@ -108,6 +133,9 @@ impl GrapeFile {
         (self.header.sample_rate, res_vecs)
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn streams_with_sample_rate(&self, sample_rate: u64) -> Vec<(GrapeTag, Vec<f32>)> {
         if sample_rate == self.header.sample_rate {
             self.streams_native_sample_rate().1
@@ -118,11 +146,17 @@ impl GrapeFile {
         }
     }
 
+    /// TODO
+    /// 
+    /// 
     fn attach_tags(tags: &[GrapeTag], samples: Vec<Vec<f32>>) -> Vec<(GrapeTag, Vec<f32>)> {
         assert_eq!(tags.len(), samples.len());
         tags.iter().cloned().zip(samples.into_iter()).collect()
     }
 
+    /// TODO
+    /// 
+    /// 
     fn get_raw_streams(&self) -> Vec<Vec<f32>> {
         let n_streams = self.header.n_streams as usize;
         if n_streams == 0 {
@@ -138,6 +172,9 @@ impl GrapeFile {
         sample_vecs
     }
 
+    /// TODO
+    /// 
+    /// 
     fn streams_interpolated(&self, sample_rate: u64) -> Vec<(GrapeTag, Vec<f32>)> {
         debug_assert!(sample_rate > self.header.sample_rate);
         let samples_per_pt = sample_rate as usize / self.header.sample_rate as usize;
@@ -158,6 +195,9 @@ impl GrapeFile {
         Self::attach_tags(&self.header.tags, interpolated_streams)
     }
 
+    /// TODO
+    /// 
+    /// 
     fn streams_quantized(&self, sample_rate: u64) -> Vec<(GrapeTag, Vec<f32>)> {
         debug_assert!(sample_rate < self.header.sample_rate);
         let pts_per_sample = self.header.sample_rate as usize / sample_rate as usize;
@@ -174,6 +214,10 @@ impl GrapeFile {
     }
 }
 
+
+/// TODO
+/// 
+/// 
 #[derive(Debug, Clone)]
 struct GrapeFileBuilder {
     n_streams: u64,
@@ -182,12 +226,20 @@ struct GrapeFileBuilder {
 }
 
 impl Default for GrapeFileBuilder {
+
+    /// TODO
+    /// 
+    /// 
     fn default() -> Self {
         Self::new()
     }
 }
 
 impl GrapeFileBuilder {
+
+    /// TODO
+    /// 
+    /// 
     fn new() -> Self {
         GrapeFileBuilder {
             n_streams: 0,
@@ -196,6 +248,9 @@ impl GrapeFileBuilder {
         }
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn set_samplerate(self, sample_rate: u64) -> Self {
         GrapeFileBuilder {
             sample_rate,
@@ -203,6 +258,9 @@ impl GrapeFileBuilder {
         }
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn add_stream(mut self, stream: &[f32], tag: GrapeTag) -> Self {
         let stream: Vec<f32> = stream.to_vec();
         self.streams.push((tag, stream));
@@ -210,12 +268,18 @@ impl GrapeFileBuilder {
         self
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn clear_streams(mut self) -> Self {
         self.streams.clear();
         self.n_streams = 0;
         self
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn build_truncate(self) -> GrapeFile {
         let tags: Vec<GrapeTag> = self
             .streams
@@ -247,6 +311,9 @@ impl GrapeFileBuilder {
         }
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn build_extend(self) -> GrapeFile {
         let tags: Vec<GrapeTag> = self
             .streams
@@ -287,6 +354,9 @@ impl GrapeFileBuilder {
         }
     }
 
+    /// TODO
+    /// 
+    /// 
     pub fn build(self) -> Result<GrapeFile, GrapeFileError> {
         let lens: Vec<usize> = self.streams.iter().map(|(_tag, v)| v.len()).collect();
 


### PR DESCRIPTION
If you want to view the compiled documentation, run `cargo doc` then go to `CyberGrape/target/doc/cg/spatial_data_format/index.html` in safari or whatever your web browser is.